### PR TITLE
Make it build on gcc6

### DIFF
--- a/backend.pro
+++ b/backend.pro
@@ -36,7 +36,7 @@
     win32: INCLUDEPATH += C:/msys64/mingw64/include C:/msys64/mingw64/include/SDL2 # MSYS2
     macx:  INCLUDEPATH += /usr/local/include /usr/local/include/SDL2               # Homebrew
     macx:  INCLUDEPATH += /usr/local/include /opt/local/include/SDL2               # MacPorts
-    unix:  INCLUDEPATH += /usr/include /usr/include/SDL2                           # Linux
+    unix:  INCLUDEPATH += /usr/include/SDL2                                        # Linux
 
     # Include externals
     DEFINES += QUAZIP_STATIC


### PR DESCRIPTION
Fix team-phoenix/Phoenix#263 by removing `/usr/include` from Unix include path
Accompanying frontend fix: team-phoenix/Phoenix#264

TODO: Test on gcc5 and earlier
